### PR TITLE
Fix logger import in load-config

### DIFF
--- a/src/config/load-config.js
+++ b/src/config/load-config.js
@@ -8,7 +8,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { validateRagrcSchema } from './validate-schema.js';
-import logger from '../utils/logger.js';
+import { logger } from '../utils/logger.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);


### PR DESCRIPTION
## Summary
- use named logger import in `load-config.js`

## Testing
- `node --test __tests__/integration/config/load-config.test.js` *(fails: Cannot find package 'ajv')*