### PR TITLE
Fix plugin contract validator

### DIFF
--- a/__tests__/unit/utils/validate-plugin-contract.test.js
+++ b/__tests__/unit/utils/validate-plugin-contract.test.js
@@ -1,0 +1,24 @@
+import { validatePluginContract } from '../../../src/utils/validate-plugin-contract.js';
+
+const dummyPath = 'mock-plugin.js';
+
+describe('validatePluginContract', () => {
+  test('passes when plugin implements required methods', () => {
+    const plugin = { load() {} };
+    expect(() => validatePluginContract('loader', plugin, dummyPath)).not.toThrow();
+  });
+
+  test('throws error when required methods are missing', () => {
+    const plugin = {};
+    expect(() => validatePluginContract('loader', plugin, dummyPath)).toThrow(
+      `[validatePluginContract] Plugin '${dummyPath}' is missing required methods for 'loader': load`
+    );
+  });
+
+  test('throws error for unknown plugin type', () => {
+    const plugin = {};
+    expect(() => validatePluginContract('unknown', plugin, dummyPath)).toThrow(
+      `[validatePluginContract] Unknown plugin type: unknown`
+    );
+  });
+});

--- a/src/utils/validate-plugin-contract.js
+++ b/src/utils/validate-plugin-contract.js
@@ -15,10 +15,12 @@ import { pluginContracts } from '../core/plugin-contracts.js';
  * @throws {Error} if any required method is missing or not a function
  */
 export function validatePluginContract(type, instance, filePath) {
-  const expectedMethods = pluginContracts[type];
-  if (!expectedMethods) {
+  const contract = pluginContracts[type];
+  if (!contract) {
     throw new Error(`[validatePluginContract] Unknown plugin type: ${type}`);
   }
+
+  const expectedMethods = contract.requiredMethods;
 
   const missing = expectedMethods.filter(method =>
     typeof instance[method] !== 'function'


### PR DESCRIPTION
## Summary
- fix expected methods lookup in `validatePluginContract`
- add unit tests for `validatePluginContract` error handling

## Testing
- `npm ci --ignore-scripts --silent` *(failed: command interrupted)*